### PR TITLE
Camera gets stuck on STATE_CAPTURING indefinitely

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.4+10
+* Fix a halt issue for pixel 6 users
+
 ## 0.9.4+9
 
 * iOS performance improvement by moving sample buffer handling from the main queue to a background session queue. 

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -584,7 +584,6 @@ class Camera
 
     try {
       captureSession.stopRepeating();
-      captureSession.abortCaptures();
       Log.i(TAG, "sending capture request");
       captureSession.capture(stillBuilder.build(), captureCallback, backgroundHandler);
     } catch (CameraAccessException e) {
@@ -722,9 +721,8 @@ class Camera
         cameraFeatureFactory.createAutoFocusFeature(cameraProperties, false));
     recordingVideo = false;
     try {
-      captureSession.abortCaptures();
       mediaRecorder.stop();
-    } catch (CameraAccessException | IllegalStateException e) {
+    } catch (IllegalStateException e) {
       // Ignore exceptions and try to continue (changes are camera session already aborted capture).
     }
     mediaRecorder.reset();

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.4+9
+version: 0.9.4+10
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Pixel 6 user cannot take pictures as camera gets stuck in CameraCaptureCallback | state: STATE_CAPTURING | afState: 4 | aeState: 2 indefinitely

